### PR TITLE
Add context menu for running a single CQL definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,17 +92,27 @@
         "command": "cql.action.executeCqlFile",
         "title": "Execute CQL File",
         "category": "CQL"
+      },
+      {
+        "command": "cql.action.executeCqlExpression",
+        "title": "Execute CQL Expression",
+        "category": "CQL"
       }
     ],
     "menus": {
       "editor/context": [
         {
-          "command": "cql.action.viewElm",
-          "when": "editorLangId == cql",
+          "command": "cql.action.executeCqlExpression",
+          "when": "(editorLangId == cql) && editorTextFocus",
           "group": "1_cqlactions"
         },
         {
           "command": "cql.action.executeCqlFile",
+          "when": "editorLangId == cql",
+          "group": "1_cqlactions"
+        },
+        {
+          "command": "cql.action.viewElm",
           "when": "editorLangId == cql",
           "group": "1_cqlactions"
         }

--- a/package.json
+++ b/package.json
@@ -89,8 +89,8 @@
         "category": "CQL"
       },
       {
-        "command": "cql.action.executeCql",
-        "title": "Execute CQL",
+        "command": "cql.action.executeCqlFile",
+        "title": "Execute CQL File",
         "category": "CQL"
       }
     ],
@@ -102,7 +102,7 @@
           "group": "1_cqlactions"
         },
         {
-          "command": "cql.action.executeCql",
+          "command": "cql.action.executeCqlFile",
           "when": "editorLangId == cql",
           "group": "1_cqlactions"
         }

--- a/src/buildParameters.ts
+++ b/src/buildParameters.ts
@@ -7,16 +7,16 @@ import * as fse from 'fs-extra';
 import path from 'path';
 
 export type EvaluationParameters = {
-  operationArgs: string[] | undefined,
-  outputPath: Uri | undefined,
-  testPath: Uri | undefined
-}
+  operationArgs: string[] | undefined;
+  outputPath: Uri | undefined;
+  testPath: Uri | undefined;
+};
 
 // Should be working with normalized data
 export function buildParameters(uri: Uri): EvaluationParameters {
   if (!fs.existsSync(uri.fsPath)) {
     window.showInformationMessage('No library content found. Please save before executing.');
-    return {operationArgs: undefined, outputPath: undefined, testPath: undefined};
+    return { operationArgs: undefined, outputPath: undefined, testPath: undefined };
   }
 
   const libraryDirectory = Utils.dirname(uri);
@@ -66,8 +66,8 @@ export function buildParameters(uri: Uri): EvaluationParameters {
   let evaluationParams: EvaluationParameters = {
     operationArgs,
     outputPath,
-    testPath
-  }
+    testPath,
+  };
   return evaluationParams;
 }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -45,7 +45,7 @@ export namespace Commands {
    * Execute CQL
    * TODO: Deprecate once full debugging support exists
    */
-  export const EXECUTE_CQL_COMMAND = 'cql.action.executeCql';
+  export const EXECUTE_CQL_FILE_COMMAND = 'cql.action.executeCqlFile';
   export const EXECUTE_CQL = 'org.opencds.cqf.cql.ls.plugin.debug.startDebugSession';
 
   /*

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -46,6 +46,7 @@ export namespace Commands {
    * TODO: Deprecate once full debugging support exists
    */
   export const EXECUTE_CQL_FILE_COMMAND = 'cql.action.executeCqlFile';
+  export const EXECUTE_CQL_EXPRESSION_COMMAND = 'cql.action.executeCqlExpression';
   export const EXECUTE_CQL = 'org.opencds.cqf.cql.ls.plugin.debug.startDebugSession';
 
   /*

--- a/src/cqlLanguageClient.ts
+++ b/src/cqlLanguageClient.ts
@@ -142,7 +142,13 @@ export class CqlLanguageClient {
 
     context.subscriptions.push(
       commands.registerCommand(Commands.EXECUTE_CQL_FILE_COMMAND, async (uri: Uri) => {
-        await normalizeCqlExecution(uri);
+        await normalizeCqlExecution(uri, 'file');
+      }),
+    );
+
+    context.subscriptions.push(
+      commands.registerCommand(Commands.EXECUTE_CQL_EXPRESSION_COMMAND, async (uri: Uri) => {
+        await normalizeCqlExecution(uri, 'expression');
       }),
     );
   }

--- a/src/cqlLanguageClient.ts
+++ b/src/cqlLanguageClient.ts
@@ -141,7 +141,7 @@ export class CqlLanguageClient {
     );
 
     context.subscriptions.push(
-      commands.registerCommand(Commands.EXECUTE_CQL_COMMAND, async (uri: Uri) => {
+      commands.registerCommand(Commands.EXECUTE_CQL_FILE_COMMAND, async (uri: Uri) => {
         await executeCQLFile(uri);
       }),
     );

--- a/src/normalizeCqlExecution.ts
+++ b/src/normalizeCqlExecution.ts
@@ -1,19 +1,16 @@
-import { Uri, window } from "vscode";
-import { buildParameters } from "./buildParameters";
-import { executeCQL } from "./executeCql";
+import { Uri, window } from 'vscode';
+import { buildParameters } from './buildParameters';
+import { executeCQL } from './executeCql';
 
-export async function normalizeCqlExecution(uri: Uri) {
+export async function normalizeCqlExecution(uri: Uri, mode: 'expression' | 'file') {
+  // Needs a distinction between CQL file and single line
+  const isCqlFile = window.activeTextEditor!.document.fileName.endsWith('.cql');
 
-    // Needs a distinction between CQL file and single line
-    const isCqlFile = window.activeTextEditor!.document.fileName.endsWith(".cql");
-
-    if (isCqlFile) {
-        // should normalize data
-        let operationArgs = buildParameters(uri)
-        executeCQL(operationArgs)
-    } else {
-        window.showInformationMessage('As of now we only support Cql File Execution and execution needs to run a .cql file.');
-    }
-    
+  if (isCqlFile && mode === 'file') {
+    // should normalize data
+    let operationArgs = buildParameters(uri);
+    executeCQL(operationArgs);
+  } else {
+    window.showInformationMessage('Only execution of whole CQL files is currently supported.');
+  }
 }
-


### PR DESCRIPTION
Currently calls `normalizeCqlExecution`, which will fail stating that it only supports executing whole files.