### PR TITLE
Move jars to a separate directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ server
 *.vsix
 target
 dist
+jars/
 bin
 .vscode-test
 coverage/

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -4,7 +4,7 @@ src/
 *.vsix
 .gitignore
 tsconfig.json
-dist/jars
+jars/
 dist/test
 
 .vscode-test

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Run the `debug` launch from VS Code
 TIP: The cql-language-server that provides error highlighting is a Java project. It's also launched in debug mode when this VS Code extension is launched in debug mode, allowing you to attach a Java debugger as well. If you're simultaneously iterating on the cql-language-server, you can create a symlink to that Java artifact and changes will be picked up when VS Code restarts.
 
 On linux:
-`vscode-cql/dist/jars$ ln -s your-repo-home/cql-language-server/ls/service/target/cql-ls-service-1.5.8.jar cql-ls-service-1.5.8.jar`
+`vscode-cql/jars$ ln -s your-repo-home/cql-language-server/ls/service/target/cql-ls-service-1.5.8.jar cql-ls-service-1.5.8.jar`
 
 Set your repo home directory and update the versions as needed.
 

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     "watch": "tsc -watch -p ./",
     "pretest": "npm run clean && npm run compile && cp -r src/test/suite/resources dist/test/suite/resources",
     "clean": "rm -rf ./dist",
+    "clean-all": "npm run clean && rm -rf ./jars",
     "test": "c8 --check-coverage --lines 80 --functions 80 --branches 80 vscode-test"
   },
   "javaDependencies": {

--- a/src/javaServiceInstaller.ts
+++ b/src/javaServiceInstaller.ts
@@ -13,7 +13,7 @@ interface MavenCoords {
 }
 
 function getJarHome(): string {
-  return path.join(__dirname, 'jars');
+  return path.join(__dirname, '../jars');
 }
 
 export function getServicePath(context: ExtensionContext, serviceName: string): string {


### PR DESCRIPTION
This PR moves the `./dist/jars/` folder to a new location (`./jars/`) to keep it from being deleted as part of `pretest` when the `test` script is run. This keeps the test from re-downloading a fresh copy of the language server jar with every run, which can be incredibly slow (often taking about 30 seconds). Now, the whole test suite completes in about 300ms, making it much more viable to iterate on - something that will be important as we work to increase test coverage.

I did consider finding a way to clear out everything in `./dist/` *except* `jars/`, but that turned out to be [more involved than should be necessary](https://unix.stackexchange.com/a/153863), so this is cleaner.