### PR TITLE
adds UI tests

### DIFF
--- a/src/__test__/suite/extension/commands.test.ts
+++ b/src/__test__/suite/extension/commands.test.ts
@@ -1,0 +1,37 @@
+import { expect } from 'chai';
+import * as vscode from 'vscode';
+
+const EXPECTED_COMMANDS = [
+  'cql.open.serverLog',
+  'cql.open.clientLog',
+  'cql.open.logs',
+  'cql.action.viewElm.xml',
+  'cql.action.viewElm.json',
+  'cql.action.executeCql',
+  'cql.action.executeCql.selectLibraries',
+  'cql.action.executeCql.selectTestCases',
+];
+
+suite('CQL command registration', () => {
+  suiteSetup(async () => {
+    const ext = vscode.extensions.getExtension('cqframework.cql');
+    if (!ext?.isActive) {
+      await ext?.activate();
+    }
+  });
+
+  test('all CQL commands are registered', async () => {
+    const all = await vscode.commands.getCommands(true);
+    for (const cmd of EXPECTED_COMMANDS) {
+      expect(all, `command "${cmd}" should be registered`).to.include(cmd);
+    }
+  });
+
+  test('no unexpected cql.* commands are registered', async () => {
+    const all = await vscode.commands.getCommands(true);
+    const registered = all.filter(c => c.startsWith('cql.'));
+    for (const cmd of registered) {
+      expect(EXPECTED_COMMANDS, `unexpected command "${cmd}" is registered`).to.include(cmd);
+    }
+  });
+});

--- a/src/__test__/suite/extension/extension.test.ts
+++ b/src/__test__/suite/extension/extension.test.ts
@@ -1,9 +1,5 @@
 import * as assert from 'assert';
-
-// You can import and use all API from the 'vscode' module
-// as well as import your extension to test it
 import * as vscode from 'vscode';
-// import * as myExtension from '../../extension';
 
 suite('extension activation tests', () => {
   test('extension should be present', () => {
@@ -16,5 +12,34 @@ suite('extension activation tests', () => {
       await extension?.activate();
     }
     assert.ok(extension && extension.isActive);
+  });
+});
+
+suite('non-CQL file isolation', () => {
+  suiteSetup(async () => {
+    const ext = vscode.extensions.getExtension('cqframework.cql');
+    if (!ext?.isActive) {
+      await ext?.activate();
+    }
+  });
+
+  test('JSON file has languageId "json", not "cql"', async () => {
+    const wsFolder = vscode.workspace.workspaceFolders?.[0];
+    assert.ok(wsFolder, 'workspace folder should be set');
+    const jsonUri = vscode.Uri.joinPath(wsFolder.uri, 'input', 'cql', 'cql-options.json');
+    const doc = await vscode.workspace.openTextDocument(jsonUri);
+    assert.strictEqual(doc.languageId, 'json');
+  });
+
+  test('no CQL diagnostics appear on JSON files', async () => {
+    const wsFolder = vscode.workspace.workspaceFolders?.[0];
+    assert.ok(wsFolder, 'workspace folder should be set');
+    const jsonUri = vscode.Uri.joinPath(wsFolder.uri, 'input', 'cql', 'cql-options.json');
+    await vscode.workspace.openTextDocument(jsonUri);
+    // Allow time for any errant diagnostic providers to fire
+    await new Promise(r => setTimeout(r, 300));
+    const diags = vscode.languages.getDiagnostics(jsonUri);
+    const cqlDiags = diags.filter(d => d.source === 'cql');
+    assert.strictEqual(cqlDiags.length, 0, 'CQL diagnostics should not appear on JSON files');
   });
 });

--- a/src/__test__/suite/extension/logCommands.test.ts
+++ b/src/__test__/suite/extension/logCommands.test.ts
@@ -1,0 +1,28 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+suite('log file commands', () => {
+  suiteSetup(async () => {
+    const ext = vscode.extensions.getExtension('cqframework.cql');
+    if (!ext?.isActive) {
+      await ext?.activate();
+    }
+  });
+
+  // The client logger is initialised during activation and writes a log file to
+  // storageUri/logs/ immediately, so the command should succeed and return true.
+  test('cql.open.clientLog opens the log file created during activation', async () => {
+    const result = await vscode.commands.executeCommand('cql.open.clientLog');
+    assert.strictEqual(result, true, 'command should open the client log file created on activation');
+  });
+
+  // cql.open.serverLog requires the language server to have run (writes
+  // storageUri/cql_ls_ws/.metadata/.log). In the test environment the server
+  // never starts, so the log file does not exist. window.showWarningMessage
+  // blocks until dismissed in a headed session, making this untestable here.
+  // Presence of the command in the palette is already verified by commands.test.ts.
+
+  // cql.open.logs delegates to both client and server log commands; the server
+  // log half will show a blocking warning notification in a headless run, so we
+  // don't test it here either.
+});

--- a/src/__test__/suite/extension/packageJson.test.ts
+++ b/src/__test__/suite/extension/packageJson.test.ts
@@ -1,0 +1,74 @@
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as path from 'path';
+
+interface PackageJson {
+  contributes: {
+    commands: Array<{ command: string; title: string }>;
+    menus: { 'editor/context': Array<{ command: string; when: string }> };
+  };
+}
+
+const pkg: PackageJson = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, '../../../../package.json'), 'utf-8')
+);
+
+const CONTEXT_MENU_COMMANDS = [
+  'cql.action.executeCql',
+  'cql.action.executeCql.selectTestCases',
+  'cql.action.viewElm.xml',
+  'cql.action.viewElm.json',
+];
+
+const EXPECTED_WHEN = 'editorLangId == cql && cql.languageServerReady';
+
+suite('package.json contributions', () => {
+  test('all expected commands are declared in contributes.commands', () => {
+    const ids = pkg.contributes.commands.map(c => c.command);
+    for (const cmd of [
+      'cql.open.serverLog',
+      'cql.open.clientLog',
+      'cql.open.logs',
+      'cql.action.viewElm.xml',
+      'cql.action.viewElm.json',
+      'cql.action.executeCql',
+      'cql.action.executeCql.selectLibraries',
+      'cql.action.executeCql.selectTestCases',
+    ]) {
+      expect(ids, `"${cmd}" should be declared in contributes.commands`).to.include(cmd);
+    }
+  });
+
+  test('context menu commands have correct when clause', () => {
+    const menuItems = pkg.contributes.menus['editor/context'];
+    for (const cmd of CONTEXT_MENU_COMMANDS) {
+      const item = menuItems.find(m => m.command === cmd);
+      expect(item, `"${cmd}" should appear in editor/context menu`).to.exist;
+      expect(item!.when, `"${cmd}" when clause`).to.equal(EXPECTED_WHEN);
+    }
+  });
+
+  test('all CQL context menu entries require editorLangId == cql', () => {
+    const menuItems = pkg.contributes.menus['editor/context'];
+    for (const item of menuItems) {
+      if (item.command.startsWith('cql.')) {
+        expect(
+          item.when,
+          `"${item.command}" should require editorLangId == cql to prevent appearing on non-CQL files`
+        ).to.include('editorLangId == cql');
+      }
+    }
+  });
+
+  test('all CQL context menu entries require cql.languageServerReady', () => {
+    const menuItems = pkg.contributes.menus['editor/context'];
+    for (const item of menuItems) {
+      if (item.command.startsWith('cql.')) {
+        expect(
+          item.when,
+          `"${item.command}" should require cql.languageServerReady to prevent appearing before server is ready`
+        ).to.include('cql.languageServerReady');
+      }
+    }
+  });
+});

--- a/src/__test__/suite/statusBar.test.ts
+++ b/src/__test__/suite/statusBar.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import * as vscode from 'vscode';
 import { statusBar } from '../../statusBar';
 
 suite('statusBar', () => {
@@ -6,41 +7,66 @@ suite('statusBar', () => {
     statusBar.setReady();
   });
 
-  test('showStatusBar() does not throw', () => {
-    expect(() => statusBar.showStatusBar()).to.not.throw();
+  test('showStatusBar() sets busy icon', () => {
+    statusBar.showStatusBar();
+    expect(statusBar.text).to.equal('$(sync~spin) CQL');
+    expect(statusBar.tooltip).to.equal('Server Busy');
   });
 
-  test('setBusy() does not throw', () => {
-    expect(() => statusBar.setBusy()).to.not.throw();
+  test('setBusy() sets spinning icon', () => {
+    statusBar.setBusy();
+    expect(statusBar.text).to.equal('$(sync~spin) CQL');
+    expect(statusBar.tooltip).to.equal('Server Busy');
   });
 
-  test('setReady() does not throw', () => {
-    expect(() => statusBar.setReady()).to.not.throw();
+  test('setReady() sets check icon', () => {
+    statusBar.setReady();
+    expect(statusBar.text).to.equal('$(check) CQL');
   });
 
-  test('setReady(version) does not throw', () => {
-    expect(() => statusBar.setReady('4.2.0')).to.not.throw();
+  test('setReady() sets Server Ready tooltip', () => {
+    statusBar.setReady();
+    const tooltip = statusBar.tooltip as vscode.MarkdownString;
+    expect(tooltip.value).to.include('Server Ready');
   });
 
-  test('setError() does not throw', () => {
-    expect(() => statusBar.setError()).to.not.throw();
+  test('setReady(version) includes version in tooltip', () => {
+    statusBar.setReady('4.2.0');
+    expect(statusBar.text).to.equal('$(check) CQL');
+    const tooltip = statusBar.tooltip as vscode.MarkdownString;
+    expect(tooltip.value).to.include('4.2.0');
   });
 
-  test('updateText() does not throw', () => {
-    expect(() => statusBar.updateText('custom text')).to.not.throw();
+  test('setError() sets error icon', () => {
+    statusBar.setError();
+    expect(statusBar.text).to.equal('$(error) CQL');
+    expect(statusBar.tooltip).to.equal('Server Error');
   });
 
-  test('updateTooltip() does not throw', () => {
-    expect(() => statusBar.updateTooltip('my tooltip')).to.not.throw();
+  test('updateText() sets custom text', () => {
+    statusBar.updateText('custom text');
+    expect(statusBar.text).to.equal('custom text');
   });
 
-  test('can transition between states without throwing', () => {
-    expect(() => {
-      statusBar.setBusy();
-      statusBar.setError();
-      statusBar.setReady('1.0.0');
-      statusBar.setBusy();
-      statusBar.setReady();
-    }).to.not.throw();
+  test('updateTooltip() sets custom tooltip', () => {
+    statusBar.updateTooltip('my tooltip');
+    expect(statusBar.tooltip).to.equal('my tooltip');
+  });
+
+  test('can transition between states', () => {
+    statusBar.setBusy();
+    expect(statusBar.text).to.equal('$(sync~spin) CQL');
+
+    statusBar.setError();
+    expect(statusBar.text).to.equal('$(error) CQL');
+
+    statusBar.setReady('1.0.0');
+    expect(statusBar.text).to.equal('$(check) CQL');
+
+    statusBar.setBusy();
+    expect(statusBar.text).to.equal('$(sync~spin) CQL');
+
+    statusBar.setReady();
+    expect(statusBar.text).to.equal('$(check) CQL');
   });
 });

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -41,6 +41,14 @@ class StatusBar implements Disposable {
     this.statusBarItem.tooltip = tooltip;
   }
 
+  public get text(): string {
+    return this.statusBarItem.text;
+  }
+
+  public get tooltip(): string | MarkdownString | undefined {
+    return this.statusBarItem.tooltip;
+  }
+
   public dispose(): void {
     this.statusBarItem.dispose();
   }


### PR DESCRIPTION
closes #146 

Upgrades the VS Code extension test suite from smoke tests ("does not throw") to behavioral assertions, and adds new test files covering command registration, package.json contributions, and non-CQL file isolation. All 102 tests pass.
