### PR TITLE
adds pre-release support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,20 +88,25 @@ Set your repo home directory and update the versions as needed.
 
 ## Versioning
 
-This project follows the guidance given by Microsoft for the VS Code marketplace [here](https://code.visualstudio.com/updates/v1_63#_publishing-prerelease-extensions) and publishes prereleases to the VS Code marketplace using odd minor version numbers. Full releases are published using even minor version numbers.
+Pre-releases are published to the VS Code Marketplace using
+`vsce publish --pre-release`. No special version number scheme is required.
+Pre-release builds reference the `<version>-SNAPSHOT` language server artifact;
+stable releases reference a tagged release artifact.
 
-## Release Process
+**To publish a pre-release:**
 
-1. Update master to be a release version (and all the reviews, bug fixes, etc. that that requires)
-    1. Update `package.json` - version to X.X.X (e.g. `0.7.7`)
-    2. Update `CHANGELOG.md` - add a new section at the top for the release version with a summary of changes (see existing entries for format)
-2. Passed CI Build = ready for release
-3. Run `vsce login cqframework` to authenticate, then `vsce publish` to publish to the VS Code Marketplace
-4. Create a github release (specify a tag of `vX.X.X` (e.g. `v0.7.7`) pointing at master to be created on release)
-    1. Choose the "Auto-generate release notes" option
-    2. Provide any additional detail/cleanup on the release notes
-5. Update master version to the next snapshot version `X.X.X-SNAPSHOT` (e.g. `0.7.8-SNAPSHOT`)
-6. Close all issues included in the release
+```sh
+vsce login cqframework
+npm run publish:prerelease
+```
+
+**To publish a stable release:**
+
+1. Set `javaDependencies.cql-language-server.version` in `package.json` to the released LS version
+2. Update `CHANGELOG.md`
+3. `vsce login cqframework && npm run publish`
+4. Create a GitHub release tag `vX.X.X`
+5. Bump version in `package.json` for next dev cycle
 
 ## Acknowledgements
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cql",
-  "version": "0.7.13-SNAPSHOT",
+  "version": "0.7.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cql",
-      "version": "0.7.13-SNAPSHOT",
+      "version": "0.7.13",
       "license": "Apache-2.0",
       "dependencies": {
         "expand-tilde": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cql",
-  "version": "0.7.13-SNAPSHOT",
+  "version": "0.7.13",
   "displayName": "Clinical Quality Language (CQL)",
   "description": "Syntax highlighting, linting, and execution for the HL7 Clinical Quality Language (CQL) for VS Code",
   "publisher": "cqframework",
@@ -170,7 +170,9 @@
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "pretest": "npm run compile",
-    "test": "vscode-test"
+    "test": "vscode-test",
+    "publish": "vsce publish",
+    "publish:prerelease": "vsce publish --pre-release"
   },
   "javaDependencies": {
     "cql-language-server": {

--- a/src/java-support/javaServiceInstaller.ts
+++ b/src/java-support/javaServiceInstaller.ts
@@ -61,13 +61,49 @@ function getLocalName(coords: MavenCoords): string {
   }${coords.type ? '.' + coords.type : '.jar'}`;
 }
 
-function getSearchUrl(coords: MavenCoords): string {
+const SNAPSHOT_REPO = 'https://central.sonatype.com/repository/maven-snapshots/';
+
+function isSnapshot(version: string): boolean {
+  return version.endsWith('-SNAPSHOT');
+}
+
+async function resolveSnapshotUrl(coords: MavenCoords): Promise<string> {
+  const groupPath = coords.groupId.replace(/\./g, '/');
+  const metaUrl = `${SNAPSHOT_REPO}${groupPath}/${coords.artifactId}/${coords.version}/maven-metadata.xml`;
+
+  const response = await fetch(metaUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch snapshot metadata: ${metaUrl}`);
+  }
+
+  const xml = await response.text();
+
+  const jarBlock = xml.match(
+    /<snapshotVersion>[\s\S]*?<extension>jar<\/extension>[\s\S]*?<\/snapshotVersion>/,
+  );
+  if (!jarBlock) {
+    throw new Error('No jar snapshotVersion found in metadata');
+  }
+
+  const valueMatch = jarBlock[0].match(/<value>(.*?)<\/value>/);
+  if (!valueMatch) {
+    throw new Error('No value in jar snapshotVersion');
+  }
+
+  const timestampedVersion = valueMatch[1];
+  return `${SNAPSHOT_REPO}${groupPath}/${coords.artifactId}/${coords.version}/${coords.artifactId}-${timestampedVersion}.jar`;
+}
+
+async function getSearchUrl(coords: MavenCoords): Promise<string> {
+  if (isSnapshot(coords.version)) {
+    return resolveSnapshotUrl(coords);
+  }
   const groupIdAsDirectory = coords.groupId.replace(/\./gi, '/');
   return `https://repo1.maven.org/maven2/${groupIdAsDirectory}/${coords.artifactId}/${coords.version}/${getLocalName(coords)}`;
 }
 
 async function installServiceIfMissing(serviceName: string, coords: MavenCoords): Promise<void> {
-  const doesExist = isServiceInstalled(coords);
+  const doesExist = !isSnapshot(coords.version) && isServiceInstalled(coords);
   if (!doesExist) {
     return window.withProgress(
       {
@@ -105,7 +141,7 @@ async function installJar(
     progress.report({ message: `Starting download` });
   }
   ensureExists(jarHome);
-  const searchUrl = getSearchUrl(coords);
+  const searchUrl = await getSearchUrl(coords);
   const setupInfo = await setupDownload(serviceName, searchUrl);
 
   await downloadFile(


### PR DESCRIPTION
closes #148


## Problem

The extension had no way to track SNAPSHOT language server builds during active development. javaServiceInstaller.ts only knew how to download from Maven Central, which only hosts release artifacts. SNAPSHOT JARs live on the Sonatype Central snapshots repo and require resolving maven-metadata.xml to find the actual timestamped filename. The extension version was also stored with a -SNAPSHOT suffix, which vsce rejects as invalid semver.                                                                                
                                                                                                                                                                                
## Changes

  javaServiceInstaller.ts — SNAPSHOT resolution                                                                                                                                   
   
- Adds resolveSnapshotUrl(), which fetches maven-metadata.xml from the Sonatype snapshots repo and extracts the timestamped artifact value to construct the final JAR URL. 
- getSearchUrl() is now async and branches on whether the version ends with -SNAPSHOT. SNAPSHOT JARs are never cached — installServiceIfMissing always re-downloads when a  SNAPSHOT version is configured so the extension picks up the latest build on each activation. Release versions continue to resolve from Maven Central unchanged.
- package.json — version + publish scripts
- Strips -SNAPSHOT from the extension version since vsce requires valid semver. Adds publish and publish:prerelease npm scripts as convenience wrappers around vsce publish and  vsce publish --pre-release.
- README.md — updated versioning docs
- Replaces the odd/even minor version scheme (which the team doesn't use) with docs for the --pre-release flag approach. - Covers both the pre-release and stable release processes.
  
>No LS-side changes required. SNAPSHOT JARs are already published by the existing mvn deploy step in the LS CI. 