### PR TITLE
Release/0.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 
 
 
+
+## v0.9.7 (prerelease)
+
+Date: 2026-06-25
+
+* fix issue with library name resolution
+* update test config file
+* add extension version details to test case results and status bar hover tool-tip
+* bump version to 0.9.7
+
+
 ## v0.9.6 (prerelease)
 
 Date: 2026-06-13

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cql",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "displayName": "Clinical Quality Language (CQL)",
   "description": "Syntax highlighting, linting, and execution for the HL7 Clinical Quality Language (CQL) for VS Code",
   "publisher": "cqframework",
@@ -836,7 +836,7 @@
     "cql-language-server": {
       "groupId": "org.opencds.cqf.cql.ls",
       "artifactId": "cql-ls-server",
-      "version": "4.8.0"
+      "version": "4.9.0"
     }
   },
   "devDependencies": {

--- a/src/__test__/resources/simple-project/input/tests/config.json
+++ b/src/__test__/resources/simple-project/input/tests/config.json
@@ -1,4 +1,5 @@
 {
   "testCasesToExclude": [],
-  "resultFormat": "flat"
+  "resultFormat": "individual",
+  "flatResultsInSubfolder": false
 }

--- a/src/__test__/suite/commands/execute-cql-file.test.ts
+++ b/src/__test__/suite/commands/execute-cql-file.test.ts
@@ -248,30 +248,34 @@ suite('writeIndividualResultFiles()', () => {
       results: [{ libraryName: 'MyLib', expressions: [{ name: 'IPP', value: '[]' }] }],
       logs: [],
       versions: {
+        extension: '0.9.7',
         translator: '4.9.0',
         engine: '4.9.0',
-        clinicalReasoning: '4.7.0',
-        languageServer: '4.8.0',
+        clinicalReasoning: '4.8.0',
+        languageServer: '4.9.0',
       },
     };
     writeIndividualResultFiles('MyLib', undefined, [{ name: 'p1' }], response, Uri.file(tmpDir), Date.now());
     const result = readResult('MyLib', 'p1');
     expect(result.versions).to.deep.equal({
+      extension: '0.9.7',
       translator: '4.9.0',
       engine: '4.9.0',
-      clinicalReasoning: '4.7.0',
-      languageServer: '4.8.0',
+      clinicalReasoning: '4.8.0',
+      languageServer: '4.9.0',
     });
   });
 
-  test('omits versions from JSON output when not present in response', () => {
+  test('omits dependency version info from JSON output when not present in response', () => {
     const response: ExecuteCqlResponse = {
       results: [{ libraryName: 'MyLib', expressions: [{ name: 'IPP', value: '[]' }] }],
       logs: [],
     };
     writeIndividualResultFiles('MyLib', undefined, [{ name: 'p1' }], response, Uri.file(tmpDir), Date.now());
     const result = readResult('MyLib', 'p1');
-    expect(result.versions).to.be.undefined;
+    expect(result.versions).to.be.deep.equal({
+      extension: '0.9.7',
+    });
   });
 
   test('overwrites existing file on re-run', () => {

--- a/src/__test__/suite/commands/execute-cql-file.test.ts
+++ b/src/__test__/suite/commands/execute-cql-file.test.ts
@@ -291,4 +291,22 @@ suite('writeIndividualResultFiles()', () => {
     const result = readResult('MyLib', 'p1');
     expect(result.results[0].value).to.equal('[]');
   });
+
+  // Regression: a hyphenated library name (e.g. SUR716-011Assertion) must not
+  // be truncated at the first hyphen. The output directory and the libraryName
+  // field in the JSON must use the full name.
+  test('writes result files under full hyphenated library name, not truncated at first hyphen', () => {
+    const libraryName = 'SUR716-011Assertion';
+    const response: ExecuteCqlResponse = {
+      results: [{ libraryName, expressions: [{ name: 'IPP', value: '[]' }] }],
+      logs: [],
+    };
+
+    writeIndividualResultFiles(libraryName, undefined, [{ name: 'p1' }], response, Uri.file(tmpDir), Date.now());
+
+    expect(fs.existsSync(path.join(tmpDir, 'SUR716-011Assertion', 'TestCaseResult-p1.json'))).to.be.true;
+    expect(fs.existsSync(path.join(tmpDir, 'SUR716', 'TestCaseResult-p1.json'))).to.be.false;
+    const result = readResult('SUR716-011Assertion', 'p1');
+    expect(result.libraryName).to.equal('SUR716-011Assertion');
+  });
 });

--- a/src/commands/execute-cql-file.ts
+++ b/src/commands/execute-cql-file.ts
@@ -27,6 +27,11 @@ import { CqlSolution } from '../model/cqlSolution';
 import { CqlParametersConfig, ParameterEntry, ResultParameterEntry } from '../model/parameters';
 import { getMeasureReportData, getTestCases, TestCase } from '../model/testCase';
 import { VersionInfo } from '../protocol';
+import { getExtensionVersion } from '../extensionState';
+
+export interface VersionInfoWithExtension extends VersionInfo {
+  extension?: string;
+}
 
 export interface TestCaseResult {
   executedAt: string;
@@ -36,7 +41,7 @@ export interface TestCaseResult {
   parameters: ResultParameterEntry[];
   results: ExpressionResult[];
   errors: string[];
-  versions?: VersionInfo;
+  versions?: VersionInfoWithExtension;
 }
 
 export function register(context: ExtensionContext): void {
@@ -68,7 +73,7 @@ export async function executeCQLFile(
     return;
   }
 
-  const libraryName = Utils.basename(cqlFileUri).replace('.cql', '').split('-')[0];
+  const libraryName = Utils.basename(cqlFileUri).replace('.cql', '');
   const libraryDisplayName = Utils.basename(cqlFileUri).replace('.cql', '');
   const testConfig = loadTestConfig(cqlPaths.testConfigPath);
   const excludedTestCases = getExcludedTestCases(libraryName, testConfig.testCasesToExclude);
@@ -266,6 +271,7 @@ function generateTextReport(
   const lines: string[] = [];
 
   lines.push(`CQL: ${cqlPaths.libraryDirectoryPath.fsPath}`);
+  lines.push(`Extension version: ${getExtensionVersion()}`);
 
   // Map system variations cleanly via configuration definitions
   if (response.versions) {
@@ -374,7 +380,9 @@ export function writeIndividualResultFiles(
       parameters,
       results,
       errors,
-      versions: response.versions,
+      versions: {
+        extension: getExtensionVersion(),
+        ...response.versions},
     };
 
     const patientId = testCaseName ?? 'no-context';

--- a/src/commands/select-test-cases.ts
+++ b/src/commands/select-test-cases.ts
@@ -28,7 +28,7 @@ export async function selectTestCases(cqlFileUri: Uri): Promise<void> {
   }
 
   const quickPick = window.createQuickPick();
-  const libraryName = Utils.basename(cqlFileUri).replace('.cql', '').split('-')[0];
+  const libraryName = Utils.basename(cqlFileUri).replace('.cql', '');
   const testConfig = loadTestConfig(cqlPaths.testConfigPath);
   const excludedTestCases = getExcludedTestCases(libraryName, testConfig.testCasesToExclude);
   const testCases = getTestCases(

--- a/src/cql-service/cqlService.executeCql.ts
+++ b/src/cql-service/cqlService.executeCql.ts
@@ -7,12 +7,12 @@ import { CqlParametersConfig } from '../model/parameters';
 import { resolveParameters } from '../helpers/parametersHelper';
 import { extractLibraryVersion } from '../helpers/fileHelper';
 import { TestCase } from '../model/testCase';
-import { VersionInfo } from '../protocol';
+import { VersionInfoWithExtension } from '../commands/execute-cql-file';
 
 export interface ExecuteCqlResponse {
   results: LibraryResult[];
   logs: string[];
-  versions?: VersionInfo;
+  versions?: VersionInfoWithExtension;
 }
 
 export interface LibraryResult {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,7 @@ import { ClientStatus } from './extension.api';
 import * as requirements from './java-support/requirements';
 import * as log from './log-services/logger';
 import { statusBar } from './statusBar';
+import { setExtensionVersion } from './extensionState';
 
 export const EXTENSION_NAME = 'Language Support for CQL';
 
@@ -86,6 +87,9 @@ function getStorageUri(context: ExtensionContext): Uri {
 export function activate(context: ExtensionContext): Promise<void> {
   const storageUri = getStorageUri(context);
   const outputChannel = log.initialize(Uri.joinPath(storageUri, 'logs'), EXTENSION_NAME);
+
+  setExtensionVersion(context.extension.packageJSON.version);
+
   if (workspace.workspaceFolders && workspace.workspaceFolders.length > 0) {
     new CqlExplorer(context);
   }

--- a/src/extensionState.ts
+++ b/src/extensionState.ts
@@ -1,0 +1,9 @@
+let extensionVersion: string = '0.0.0';
+
+export function setExtensionVersion(version: string) {
+    extensionVersion = version;
+}
+
+export function getExtensionVersion(): string {
+    return extensionVersion;
+}

--- a/src/statusBar.ts
+++ b/src/statusBar.ts
@@ -1,6 +1,7 @@
 import { MarkdownString, StatusBarAlignment, StatusBarItem, window } from 'vscode';
 import { Disposable } from 'vscode-languageclient';
 import { VersionInfo } from './protocol';
+import { getExtensionVersion } from './extensionState';
 
 class StatusBar implements Disposable {
   private statusBarItem: StatusBarItem;
@@ -32,6 +33,7 @@ class StatusBar implements Disposable {
   public setReady(version?: string, componentVersions?: VersionInfo): void {
     this.statusBarItem.text = StatusIcon.Ready;
     const tooltip = new MarkdownString(StatusTooltip.Ready);
+    tooltip.appendMarkdown(`\n\nExtension: ${getExtensionVersion()}`)
     if (componentVersions) {
       if (componentVersions.translator) tooltip.appendMarkdown(`\n\nTranslator: ${componentVersions.translator}`);
       if (componentVersions.engine) tooltip.appendMarkdown(`\n\nEngine: ${componentVersions.engine}`);


### PR DESCRIPTION
- bumps version to 0.9.7
- updates CQL Language Server to version 4.9.0
- fixes issue with library name resolution
- add extension version details to test case results and status bar hover tool-tip

closes #180
closes #179 
closes #178 